### PR TITLE
MM v5.16+ bot fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,5 @@
 # Ignore Config Directory, Build and Config File
 /config/
 claptrap
+cl4p-tp
 config.yaml

--- a/README.md
+++ b/README.md
@@ -39,25 +39,15 @@ After downloading the release for your platform, place it in a directory and cre
 it (See [Configuration](#Configuration)). Afterwards you can start claptrap:
 
 ```
-./claptrap -config_file=config.yaml
+./claptrap --config_file=config.yaml
 ```
 
 The process does not fork and logs to stdout in the current version.
 
 ## Configuration
 
-The application is configured using a single YAML file with the following parameters:
-```
-general:
-  auto_join_all_channel: true [true/false]
-  case_dir: cases/ [directory path]
+The application is configured using a single `config.yaml` file.  Adjust all necessary options in `config.yaml.sample` for your mattermost instance.  
 
-mattermost:
-  api_url: localhost:5000 [domain/ip:port]
-  username: claptrap@example.com [email]
-  password: hunter2 [password]
-  team: nsf [mattermost team name]
-```
 
 There are various message types the bot can react on, currently implemented:
 

--- a/claptrap/claptrap.go
+++ b/claptrap/claptrap.go
@@ -1,9 +1,9 @@
 package claptrap
 
 import (
-	"github.com/DSchalla/Claptrap/rules"
+	"github.com/incidrthreat/Claptrap/rules"
 	"log"
-	"github.com/DSchalla/Claptrap/provider"
+	"github.com/incidrthreat/Claptrap/provider"
 )
 
 type BotServer struct {

--- a/cmd/claptrap/claptrap.go
+++ b/cmd/claptrap/claptrap.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"flag"
-	"github.com/DSchalla/Claptrap/claptrap"
+	"github.com/incidrthreat/Claptrap/claptrap"
 	"log"
 )
 

--- a/config.yaml.sample
+++ b/config.yaml.sample
@@ -1,0 +1,9 @@
+general:
+  auto_join_all_channel: false    #[true/false]
+  case_dir: cases/                #[directory path]
+
+mattermost:
+  api_url: localhost:8065         #[domain/ip:port]
+  username: claptrap@example.com  #[email]
+  password: hunter2               #[password]
+  team: nsf                       #[mattermost team name]

--- a/provider/mattermost.go
+++ b/provider/mattermost.go
@@ -209,6 +209,17 @@ func (m *Mattermost) GetEmailByUsername(username string) string {
 	return userInfo.Email
 }
 
+func (m *Mattermost) GetUserIDByUsername(username string) string {
+	userInfo, resp := m.client.GetUserByUsername(username, "")
+	log.Println("[+] eMail for Mattermost LookUp:", userInfo.Email)
+	if resp.Error != nil {
+		log.Println("[!] Unable to get UserInfo:", resp.Error)
+		return ""
+	}
+
+	return userInfo.Id
+}
+
 func (m *Mattermost) MessagePublic(channelID, message string) bool {
 	post := &model.Post{
 		ChannelId: channelID,

--- a/provider/mattermost.go
+++ b/provider/mattermost.go
@@ -145,8 +145,8 @@ func (m *Mattermost) addEventMetadata(event Event) Event {
 		event.UserRole = user.Roles
 	}
 
-	member, _ := m.client.GetTeamMember(m.team.Id, user.Id, "")
-	event.UserRole += " " + member.Roles
+	//member, _ := m.client.GetTeamMember(m.team.Id, user.Id, "")
+	//event.UserRole += " " + member.Roles
 
 	if event.ActorName == "" && event.ActorID != "" {
 		actor, _ = m.client.GetUser(event.ActorID, "")

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -10,6 +10,7 @@ type Provider interface {
 
 	// Get Information
 	GetEmailByUsername(username string) string
+	GetUserIDByUsername(username string) string
 
 	// Actions
 	MessagePublic(channelID, message string) bool

--- a/rules/cases.go
+++ b/rules/cases.go
@@ -6,7 +6,7 @@ import (
 	"io/ioutil"
 	"log"
 
-	"github.com/DSchalla/Claptrap/provider"
+	"github.com/incidrthreat/Claptrap/provider"
 )
 
 // Case ...

--- a/rules/cases.go
+++ b/rules/cases.go
@@ -4,10 +4,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"github.com/DSchalla/Claptrap/provider"
 	"log"
+
+	"github.com/DSchalla/Claptrap/provider"
 )
 
+// Case ...
 type Case struct {
 	Name         string
 	Conditions   []Condition
@@ -108,7 +110,7 @@ func createConditionFromRawCondition(rawCond rawCondition) (Condition, error) {
 	case "random":
 		realCondition, err = NewRandomCondition(rawCond.Likeness)
 	default:
-		err = fmt.Errorf("Invalid Condition Type: %s\n", condType)
+		err = fmt.Errorf("Invalid Condition Type: %s", condType)
 	}
 
 	return realCondition, err
@@ -129,7 +131,7 @@ func createResponseFromRawResponse(rawResp rawResponse) (Response, error) {
 	case "delete_message":
 		realResponse, err = NewDeleteMessageResponse()
 	default:
-		err = fmt.Errorf("Invalid Response Type: %s\n", respType)
+		err = fmt.Errorf("Invalid Response Type: %s", respType)
 	}
 
 	return realResponse, err

--- a/rules/conditions.go
+++ b/rules/conditions.go
@@ -6,7 +6,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/DSchalla/Claptrap/provider"
+	"github.com/incidrthreat/Claptrap/provider"
 )
 
 type Condition interface {

--- a/rules/conditions.go
+++ b/rules/conditions.go
@@ -1,18 +1,19 @@
 package rules
 
 import (
-	"math/rand"
-	"strings"
-	"github.com/DSchalla/Claptrap/provider"
-	"regexp"
 	"fmt"
+	"math/rand"
+	"regexp"
+	"strings"
+
+	"github.com/DSchalla/Claptrap/provider"
 )
 
 type Condition interface {
 	Test(event provider.Event) bool
 }
 
-func NewTextContainsCondition(condition string) (*TextContainsCondition, error){
+func NewTextContainsCondition(condition string) (*TextContainsCondition, error) {
 	return &TextContainsCondition{Condition: condition}, nil
 }
 
@@ -24,7 +25,7 @@ func (t TextContainsCondition) Test(event provider.Event) bool {
 	return strings.Contains(event.Text, t.Condition)
 }
 
-func NewTextEqualsCondition(condition string) (*TextEqualsCondition, error){
+func NewTextEqualsCondition(condition string) (*TextEqualsCondition, error) {
 	return &TextEqualsCondition{Condition: condition}, nil
 }
 
@@ -36,7 +37,7 @@ func (t TextEqualsCondition) Test(event provider.Event) bool {
 	return event.Text == t.Condition
 }
 
-func NewTextStartsWithCondition(condition string) (*TextStartsWithCondition, error){
+func NewTextStartsWithCondition(condition string) (*TextStartsWithCondition, error) {
 	return &TextStartsWithCondition{Condition: condition}, nil
 }
 
@@ -48,7 +49,7 @@ func (t TextStartsWithCondition) Test(event provider.Event) bool {
 	return strings.HasPrefix(event.Text, t.Condition)
 }
 
-func NewTextMatchesCondition(expression string) (*TextMatchesCondition, error){
+func NewTextMatchesCondition(expression string) (*TextMatchesCondition, error) {
 	var err error
 	c := &TextMatchesCondition{}
 	c.expression = expression
@@ -61,14 +62,14 @@ func NewTextMatchesCondition(expression string) (*TextMatchesCondition, error){
 
 type TextMatchesCondition struct {
 	expression string
-	regexp *regexp.Regexp
+	regexp     *regexp.Regexp
 }
 
 func (t TextMatchesCondition) Test(event provider.Event) bool {
 	return t.regexp.MatchString(event.Text)
 }
 
-func NewRandomCondition(likeness int) (*RandomCondition, error){
+func NewRandomCondition(likeness int) (*RandomCondition, error) {
 	return &RandomCondition{Likeness: likeness}, nil
 }
 
@@ -81,7 +82,7 @@ func (t RandomCondition) Test(event provider.Event) bool {
 	return t.Likeness > (randomInt % 100)
 }
 
-func NewUserEqualsCondition(condition, parameter string) (*UserEqualsCondition, error){
+func NewUserEqualsCondition(condition, parameter string) (*UserEqualsCondition, error) {
 
 	if parameter != "" && parameter != "user" && parameter != "actor" {
 		return nil, fmt.Errorf("unknown Parameter for UserIDEqualsCondition: '%s'", parameter)
@@ -110,7 +111,7 @@ func (u UserEqualsCondition) Test(event provider.Event) bool {
 	return (userID == u.Condition) || (userName == u.Condition)
 }
 
-func NewUserIsRoleCondition(condition, parameter string) (*UserIsRoleCondition, error){
+func NewUserIsRoleCondition(condition, parameter string) (*UserIsRoleCondition, error) {
 
 	if parameter != "" && parameter != "user" && parameter != "actor" {
 		return nil, fmt.Errorf("unknown Parameter for UserIsRoleCondition: '%s'", parameter)
@@ -136,7 +137,7 @@ func (u UserIsRoleCondition) Test(event provider.Event) bool {
 	return strings.Contains(role, u.Condition)
 }
 
-func NewChannelEqualsCondition(condition string) (*ChannelEqualsCondition, error){
+func NewChannelEqualsCondition(condition string) (*ChannelEqualsCondition, error) {
 	return &ChannelEqualsCondition{Condition: condition}, nil
 }
 
@@ -148,8 +149,7 @@ func (c ChannelEqualsCondition) Test(event provider.Event) bool {
 	return (event.ChannelID == c.Condition) || (event.ChannelName == c.Condition)
 }
 
-
-func NewChannelIsTypeCondition(condition string) (*ChannelIsTypeCondition, error){
+func NewChannelIsTypeCondition(condition string) (*ChannelIsTypeCondition, error) {
 	return &ChannelIsTypeCondition{Condition: condition}, nil
 }
 

--- a/rules/conditions_test.go
+++ b/rules/conditions_test.go
@@ -1,9 +1,10 @@
 package rules_test
 
 import (
-	"github.com/DSchalla/Claptrap/rules"
 	"testing"
+
 	"github.com/DSchalla/Claptrap/provider"
+	"github.com/DSchalla/Claptrap/rules"
 )
 
 func TestTextContainsCondition(t *testing.T) {
@@ -83,7 +84,6 @@ func TestUserEqualsCondition_Test(t *testing.T) {
 	}
 
 	cond, _ = rules.NewUserEqualsCondition("foobar", "actor")
-
 
 	if !cond.Test(provider.Event{ActorName: "foobar"}) {
 		t.Errorf("Expected True, got False")
@@ -174,7 +174,6 @@ func TestChannelIsTypeCondition_Test(t *testing.T) {
 	}
 
 	cond, _ = rules.NewChannelIsTypeCondition("dm")
-
 
 	if !cond.Test(provider.Event{ChannelType: "D"}) {
 		t.Errorf("Expected True, Got False")

--- a/rules/conditions_test.go
+++ b/rules/conditions_test.go
@@ -3,8 +3,8 @@ package rules_test
 import (
 	"testing"
 
-	"github.com/DSchalla/Claptrap/provider"
-	"github.com/DSchalla/Claptrap/rules"
+	"github.com/incidrthreat/Claptrap/provider"
+	"github.com/incidrthreat/Claptrap/rules"
 )
 
 func TestTextContainsCondition(t *testing.T) {

--- a/rules/engine.go
+++ b/rules/engine.go
@@ -1,13 +1,14 @@
 package rules
 
 import (
-	"github.com/fsnotify/fsnotify"
 	"log"
 	"os"
 	"path"
-	"strings"
 	"path/filepath"
+	"strings"
+
 	"github.com/DSchalla/Claptrap/provider"
+	"github.com/fsnotify/fsnotify"
 )
 
 var caseTypes = []string{"message", "user_add", "user_remove"}

--- a/rules/engine.go
+++ b/rules/engine.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/DSchalla/Claptrap/provider"
+	"github.com/incidrthreat/Claptrap/provider"
 	"github.com/fsnotify/fsnotify"
 )
 

--- a/rules/engine_test.go
+++ b/rules/engine_test.go
@@ -1,9 +1,10 @@
 package rules_test
 
 import (
-	"github.com/DSchalla/Claptrap/rules"
 	"testing"
+
 	"github.com/DSchalla/Claptrap/provider"
+	"github.com/DSchalla/Claptrap/rules"
 )
 
 func TestEngine_EvaluateMessageEvent(t *testing.T) {

--- a/rules/responses.go
+++ b/rules/responses.go
@@ -3,7 +3,7 @@ package rules
 import (
 	"log"
 
-	"github.com/icnidrthreat/Claptrap/provider"
+	"github.com/incidrthreat/Claptrap/provider"
 )
 
 type Response interface {

--- a/rules/responses.go
+++ b/rules/responses.go
@@ -2,6 +2,7 @@ package rules
 
 import (
 	"log"
+
 	"github.com/DSchalla/Claptrap/provider"
 )
 
@@ -9,7 +10,7 @@ type Response interface {
 	Execute(p provider.Provider, event provider.Event) bool
 }
 
-func NewMessageChannelResponse(channelID, message string) (*MessageChannelResponse, error){
+func NewMessageChannelResponse(channelID, message string) (*MessageChannelResponse, error) {
 	return &MessageChannelResponse{channelID, message}, nil
 }
 
@@ -21,7 +22,7 @@ type MessageChannelResponse struct {
 func (k MessageChannelResponse) Execute(p provider.Provider, event provider.Event) bool {
 	message := p.ReplaceMessagePlaceholders(event, k.message)
 	channelID := ""
-	if len(k.channelID) == 0{
+	if len(k.channelID) == 0 {
 		channelID = event.ChannelID
 	} else {
 		channelID = k.channelID
@@ -31,10 +32,9 @@ func (k MessageChannelResponse) Execute(p provider.Provider, event provider.Even
 	return p.MessagePublic(channelID, message)
 }
 
-func NewMessageUserResponse(userID, message string) (*MessageUserResponse, error){
+func NewMessageUserResponse(userID, message string) (*MessageUserResponse, error) {
 	return &MessageUserResponse{userID, message}, nil
 }
-
 
 type MessageUserResponse struct {
 	userID  string
@@ -56,7 +56,7 @@ func (k MessageUserResponse) Execute(p provider.Provider, event provider.Event) 
 	return p.MessageUser(userID, message)
 }
 
-func NewInviteUserResponse(channelID, userID string) (*InviteUserResponse, error){
+func NewInviteUserResponse(channelID, userID string) (*InviteUserResponse, error) {
 	return &InviteUserResponse{channelID, userID}, nil
 }
 
@@ -79,7 +79,7 @@ func (k InviteUserResponse) Execute(p provider.Provider, event provider.Event) b
 	return p.InviteUser(userID, k.channelID)
 }
 
-func NewKickUserResponse(channelID, userID string) (*KickUserResponse, error){
+func NewKickUserResponse(channelID, userID string) (*KickUserResponse, error) {
 	return &KickUserResponse{channelID, userID}, nil
 }
 
@@ -99,7 +99,7 @@ func (k KickUserResponse) Execute(p provider.Provider, event provider.Event) boo
 
 	channelID := ""
 	channelName := ""
-	if len(k.ChannelID) == 0{
+	if len(k.ChannelID) == 0 {
 		channelID = event.ChannelID
 		channelName = event.ChannelName
 	} else {
@@ -111,7 +111,7 @@ func (k KickUserResponse) Execute(p provider.Provider, event provider.Event) boo
 	return p.KickUser(userID, channelID)
 }
 
-func NewDeleteMessageResponse() (*DeleteMessageResponse, error){
+func NewDeleteMessageResponse() (*DeleteMessageResponse, error) {
 	return &DeleteMessageResponse{}, nil
 }
 

--- a/rules/responses.go
+++ b/rules/responses.go
@@ -3,7 +3,7 @@ package rules
 import (
 	"log"
 
-	"github.com/DSchalla/Claptrap/provider"
+	"github.com/icnidrthreat/Claptrap/provider"
 )
 
 type Response interface {

--- a/rules/responses_test.go
+++ b/rules/responses_test.go
@@ -1,10 +1,11 @@
 package rules_test
 
 import (
-	"testing"
-	"github.com/DSchalla/Claptrap/rules"
 	"os"
+	"testing"
+
 	"github.com/DSchalla/Claptrap/provider"
+	"github.com/DSchalla/Claptrap/rules"
 )
 
 var prov *provider.Debug
@@ -13,11 +14,11 @@ var event provider.Event
 func TestMain(m *testing.M) {
 	prov = provider.NewDebug()
 	event = provider.Event{
-		PostID:		 "Post1",
+		PostID:      "Post1",
 		UserID:      "User1",
 		UserName:    "Username1",
-		ActorID: 	 "Actor1",
-		ActorName: 	 "Actorname1",
+		ActorID:     "Actor1",
+		ActorName:   "Actorname1",
 		ChannelID:   "Channel1",
 		ChannelName: "Channelname1",
 		Text:        "hunter2",
@@ -134,7 +135,6 @@ func TestInviteUserResponse(t *testing.T) {
 	}
 }
 
-
 func TestKickUserResponse(t *testing.T) {
 	resp, err := rules.NewKickUserResponse("", "")
 	res := resp.Execute(prov, event)
@@ -174,7 +174,6 @@ func TestKickUserResponse(t *testing.T) {
 		t.Errorf("Expected User2, got %s", prov.KickUserLog[1].UserID)
 	}
 }
-
 
 func TestDeleteMessageResponse(t *testing.T) {
 	resp, err := rules.NewDeleteMessageResponse()


### PR DESCRIPTION
* Added a few changes to README.
    - Edited installation section to reflect `--` in args
    - Made reference to config.yml.sample in configuration section
* Added config.yaml.sample to ease confusion for others wanting to dev/use the bot
* Go auto-formatted a few lines (doesn't change operation) of the following:
    - rules/cases.go
    - rules/conditions.go
    - rules/conditions_test.go
    - rules/responses.go
    - rules/responses_test.go
    - rules/engine.go 
    - rules/engine_test.go
* Main change was commenting out the member and event.UserRole in `provider/mattermost.go`: 
```
	//member, _ := m.client.GetTeamMember(m.team.Id, user.Id, "")
	//event.UserRole += " " + member.Roles

	if event.ActorName == "" && event.ActorID != "" {
		actor, _ = m.client.GetUser(event.ActorID, "")
	} else if event.ActorName != "" && event.ActorID == "" {
		actor, _ = m.client.GetUserByUsername(event.ActorName, "")
	}

	if actor != nil {
		event.ActorID = actor.Id
		event.ActorName = actor.Username
		event.ActorRole = actor.Roles

		//member, _ = m.client.GetTeamMember(m.team.Id, actor.Id, "")
		//event.ActorRole += " " + member.Roles
	}
```

Not sure what conflicts happen here, I could not find any usage in the bot for those 4 lines.  Will inquire more later.  For now the bot is running.
